### PR TITLE
fix the order of domain and intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ We also provide database in `data/crosswoz/database`.
     - content: utterance
     - role: user or system side
     - dialog_act: list of dialog act tuples, includes:
-      - domain
       - intent
+      - domain 
       - slot
       - value
     - user_state: same format as "goal", can be viewed as dynamic goal


### PR DESCRIPTION
**Description:**

```
        "Inform",   # 意图
        "景点",      # 领域 
        "门票",      # slot
        "免费"       # value
```


**Reference:** 

https://github.com/thu-coai/CrossWOZ/blob/4edfcb6104adcd4634729fd47ef5fecab30ec2b5/convlab2/nlg/sclstm/crosswoz/sc_lstm.py#L90-L101